### PR TITLE
Don't die if you trie to collector.WriteListToFile is asked to write to the current working directory

### DIFF
--- a/alphatwirl/collector/WriteListToFile.py
+++ b/alphatwirl/collector/WriteListToFile.py
@@ -21,7 +21,9 @@ class WriteListToFile(object):
         self._close(f)
 
     def _open(self, path):
-        mkdir_p(os.path.dirname(path))
+        directory = os.path.dirname(path)
+        if directory:
+            mkdir_p(directory)
         return open(path, 'w')
 
     def _close(self, file): file.close()


### PR DESCRIPTION
The current implementation of WriteListToFile tries to create the directory for its output file, regardless of whether or not the given path to the output file actually contains a directory.  Since mkdir_p doesn't check whether it is given an empty string, things die.  I think that is the correct behaviour for mkdir_p so I've added a check into WriteListToFile to see if there is a directory to be made.  With this in, things work ok