### PR TITLE
Add .pytest_cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ target/
 *~
 .*sw[op]
 tests/profile_*.txt
+.pytest_cache


### PR DESCRIPTION
When you run `pytest` it creates a cache directory which git would identify as an untracked file.  So add this to the gitignore file