### PR TITLE
Refactor TaskPackageDropbox

### DIFF
--- a/alphatwirl/concurrently/TaskPackageDropbox.py
+++ b/alphatwirl/concurrently/TaskPackageDropbox.py
@@ -103,6 +103,10 @@ class TaskPackageDropbox(object):
             if pkgidx_result_pair and not pkgidx_result_pair[1]:
                 pkgidx_result_pair = None
 
+            # early break to avoid sleeping
+            if pkgidx_result_pair:
+                break
+
             time.sleep(self.sleep)
 
         return pkgidx_result_pair
@@ -118,6 +122,11 @@ class TaskPackageDropbox(object):
             pkgidx_result_pairs.extend(
                 self._collect_all_finished_pkgidx_result_pairs()
             )
+
+            # early break to avoid sleeping
+            if not self.runid_pkgidx_map:
+                break
+
             time.sleep(self.sleep)
 
         # remove failed results and sort in the order of pkgidx

--- a/tests/unit/concurrently/test_TaskPackageDropbox_put.py
+++ b/tests/unit/concurrently/test_TaskPackageDropbox_put.py
@@ -51,10 +51,41 @@ def test_open_terminate_close(workingarea, dispatcher):
     assert 1 == workingarea.close.call_count
     assert 1 == dispatcher.terminate.call_count
 
-def test_put(obj, workingarea, dispatcher):
+def test_run(obj, workingarea, dispatcher):
+
+    dispatcher.run.side_effect = [1001, 1002] # runid
+
+    assert 0 == obj.run(0)
+    assert 1 == obj.run(1)
+
+    assert {1001: 0, 1002: 1} == obj.runid_pkgidx_map
+    assert [mock.call(workingarea, 0), mock.call(workingarea, 1)] == dispatcher.run.call_args_list
+
+def test_run_multiple(obj, workingarea, dispatcher):
+
+    dispatcher.run_multiple.return_value = [1001, 1002] # runid
+
+    assert [0, 1] == obj.run_multiple([0, 1])
+
+    assert {1001: 0, 1002: 1} == obj.runid_pkgidx_map
+    assert [mock.call(workingarea, [0, 1])] == dispatcher.run_multiple.call_args_list
+
+def test_resubmit(obj, dispatcher):
+
+    assert 0 == obj.resubmit(1001, 0)
+    assert 1 == obj.resubmit(1002, 1)
+
+    assert [mock.call([1001]), mock.call([1002])] == dispatcher.failed_runids.call_args_list
+
+def test_resubmit_multiple(obj, dispatcher):
+
+    assert [0, 1] == obj.resubmit_multiple([1001, 1002], [0, 1])
+
+    assert [mock.call([1001, 1002])] == dispatcher.failed_runids.call_args_list
+
+def test_put(obj, workingarea):
 
     workingarea.put_package.side_effect = [0, 1] # pkgidx
-    dispatcher.run.side_effect = [1001, 1002] # runid
 
     package0 = mock.MagicMock(name='package0')
     package1 = mock.MagicMock(name='package1')
@@ -63,12 +94,10 @@ def test_put(obj, workingarea, dispatcher):
     assert 1 == obj.put(package1)
 
     assert [mock.call(package0), mock.call(package1)] == workingarea.put_package.call_args_list
-    assert [mock.call(workingarea, 0), mock.call(workingarea, 1)] == dispatcher.run.call_args_list
 
-def test_put_multiple(obj, workingarea, dispatcher):
+def test_put_multiple(obj, workingarea):
 
     workingarea.put_package.side_effect = [0, 1] # pkgidx
-    dispatcher.run_multiple.return_value = [1001, 1002] # runid
 
     package0 = mock.MagicMock(name='package0')
     package1 = mock.MagicMock(name='package1')
@@ -76,6 +105,5 @@ def test_put_multiple(obj, workingarea, dispatcher):
     assert [0, 1] == obj.put_multiple([package0, package1])
 
     assert [mock.call(package0), mock.call(package1)] == workingarea.put_package.call_args_list
-    assert [mock.call(workingarea, [0, 1])] == dispatcher.run_multiple.call_args_list
 
 ##__________________________________________________________________||

--- a/tests/unit/concurrently/test_TaskPackageDropbox_receive.py
+++ b/tests/unit/concurrently/test_TaskPackageDropbox_receive.py
@@ -87,10 +87,7 @@ def test_receive(obj, pkgidx_result_pairs):
 
 def test_receive_dispatcher_received_failed_runids(obj, dispatcher):
     obj.receive()
-    assert [
-        mock.call([]), mock.call([]), mock.call([1002]),
-        mock.call([1005]), mock.call([])
-    ] == dispatcher.failed_runids.call_args_list
+    assert [mock.call([1002]), mock.call([1005])] == dispatcher.failed_runids.call_args_list
 
 def test_receive_logging_resubmission(obj, caplog):
     with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
Address the issue of loading in too many `result.p.gz` files which can exceed user's memory.

Changes:
* Refactor the `TaskPackageDropbox.py` class
* Split up the amount of work done by the `_collect_all_finished_pkgidx_result_pairs` method
* Add `run`, `run_multiple`, `resubmit` and `resubmit_multiple` to reflect similar functions as the other

Tested the speed difference and saw similar results between before and after these changes.

Also saw a reduction in the memory usage which is fairly flat with time, which is the main goal of this PR (will add plots profiling the memory in a bit)