### PR TITLE
Tests for TaskPackageDropbox

### DIFF
--- a/alphatwirl/concurrently/TaskPackageDropbox.py
+++ b/alphatwirl/concurrently/TaskPackageDropbox.py
@@ -129,10 +129,6 @@ class TaskPackageDropbox(object):
         return pkgidx_result_pairs
 
     def _collect_next_finished_pkgidx_result_pair(self):
-        # No runs remaining
-        if not self.runid_pkgidx_map:
-            return None
-
         if not self.runid_to_return:
             self.runid_to_return.extend(self.dispatcher.poll())
 

--- a/alphatwirl/concurrently/TaskPackageDropbox.py
+++ b/alphatwirl/concurrently/TaskPackageDropbox.py
@@ -89,11 +89,9 @@ class TaskPackageDropbox(object):
             if pkgidx_result_pair and not pkgidx_result_pair[1]:
                 pkgidx_result_pair = None
 
-            # early break to avoid sleeping
-            if pkgidx_result_pair:
-                break
-
-            time.sleep(self.sleep)
+            # Only sleep if there are no pending runs
+            if not self.runid_to_return and self.runid_pkgidx_map:
+                time.sleep(self.sleep)
 
         return pkgidx_result_pair
 
@@ -109,11 +107,9 @@ class TaskPackageDropbox(object):
                 self._collect_all_finished_pkgidx_result_pairs()
             )
 
-            # early break to avoid sleeping
-            if not self.runid_pkgidx_map:
-                break
-
-            time.sleep(self.sleep)
+            # Only sleep if we're waiting for runs
+            if self.runid_pkgidx_map:
+                time.sleep(self.sleep)
 
         # remove failed results and sort in the order of pkgidx
         pkgidx_result_pairs = filter(itemgetter(1), pkgidx_result_pairs)
@@ -125,19 +121,22 @@ class TaskPackageDropbox(object):
         pkgidx_result_pairs = []
 
         pairs = self._collect_next_finished_pkgidx_result_pair()
-        while pairs:
-            pkgidx_result_pairs.append(pairs)
+        while self.runid_to_return:
+            if pairs: pkgidx_result_pairs.append(pairs)
             pairs = self._collect_next_finished_pkgidx_result_pair()
+        if pairs: pkgidx_result_pairs.append(pairs)
 
         return pkgidx_result_pairs
 
     def _collect_next_finished_pkgidx_result_pair(self):
+        # No runs remaining
         if not self.runid_pkgidx_map:
             return None
 
         if not self.runid_to_return:
             self.runid_to_return.extend(self.dispatcher.poll())
 
+        # No finished runs remaining
         if not self.runid_to_return:
             return None
 

--- a/tests/unit/concurrently/test_TaskPackageDropbox_receive.py
+++ b/tests/unit/concurrently/test_TaskPackageDropbox_receive.py
@@ -149,6 +149,13 @@ def test_receive_one(obj, pkgidx_result_pairs):
         assert sorted(pkgidx_result_pairs) == sorted(actual)
         assert [mock.call(0.01)]*4 == sleep.call_args_list
 
+def test_receive_one_single_call(obj, pkgidx_result_pairs, workingarea):
+    with mock.patch('time.sleep') as sleep:
+        pair = obj.receive_one()
+        assert pair in pkgidx_result_pairs
+        assert [mock.call(pair[0])] == workingarea.collect_result.call_args_list
+        assert [] == sleep.call_args_list
+
 @pytest.mark.parametrize('dispatcher_poll', [
     pytest.param(
         [[1001, 1003], [ ], [1002], [1000, 1005], [1006, 1004]],

--- a/tests/unit/concurrently/test_TaskPackageDropbox_receive.py
+++ b/tests/unit/concurrently/test_TaskPackageDropbox_receive.py
@@ -141,10 +141,7 @@ def test_receive_one(obj, pkgidx_result_pairs):
     with mock.patch('time.sleep') as sleep:
         actual = [ ]
         while len(actual) < len(pkgidx_result_pairs):
-            pair = obj.receive_one()
-            if pair is None:
-                break
-            actual.append(pair)
+            actual.append(obj.receive_one())
         assert obj.receive_one() is None
         assert sorted(pkgidx_result_pairs) == sorted(actual)
         assert [mock.call(0.01)]*4 == sleep.call_args_list
@@ -176,10 +173,7 @@ def test_receive_one_param(obj, pkgidx_result_pairs, dispatcher, dispatcher_poll
 
         actual = [ ]
         while len(actual) < len(pkgidx_result_pairs):
-            pair = obj.receive_one()
-            if pair is None:
-                break
-            actual.append(pair)
+            actual.append(obj.receive_one())
         assert obj.receive_one() is None
         assert sorted(pkgidx_result_pairs) == sorted(actual)
         assert [mock.call(0.01)]*(len(dispatcher_poll)-1) == sleep.call_args_list


### PR DESCRIPTION
Fixed issue with the number of calls to `time.sleep` in `TaskPackageDropbox`. Added tests for:
1. number of calls to `time.sleep` in `TaskPackageDropbox`
2. single call of `receive_one` - test to see if `WorkingArea.collect_result` is called once (`test_receive_one_single_call`)

`time.sleep` is called by `receive` and `receive_one` only if there are no finished runs to be processed, unless all runs are finished.
