### PR TITLE
Make profile_func return the result of the function it wraps

### DIFF
--- a/alphatwirl/misc/profile_func.py
+++ b/alphatwirl/misc/profile_func.py
@@ -5,18 +5,19 @@ from io import StringIO, BytesIO
 
 ##__________________________________________________________________||
 def print_profile_func(func, profile_out_path=None):
-    result = profile_func(func)
+    profile, result = profile_func(func)
     if profile_out_path is None:
-        print(result)
+        print(profile)
     else:
         with open(profile_out_path, 'w') as f:
-            f.write(result)
+            f.write(profile)
+    return result
 
 ##__________________________________________________________________||
 def profile_func(func):
     pr = cProfile.Profile()
     pr.enable()
-    func()
+    result = func()
     pr.disable()
     sortby = 'cumulative'
     try:
@@ -25,6 +26,6 @@ def profile_func(func):
     except TypeError:
         s = BytesIO()
         pstats.Stats(pr, stream=s).strip_dirs().sort_stats(sortby).print_stats()
-    return s.getvalue()
+    return s.getvalue(), result
 
 ##__________________________________________________________________||


### PR DESCRIPTION
The profile_func provides useful functionality, but it can't currently be used transparently by a calling function because it doesn't pass through the result returned from the function it wraps.  This small PR adds this in.